### PR TITLE
fix: use react-hooks rewind channel option

### DIFF
--- a/examples/vite-component-locking/src/hooks/useLiveValue.ts
+++ b/examples/vite-component-locking/src/hooks/useLiveValue.ts
@@ -9,11 +9,14 @@ export const useLiveValue = (componentName: string, self: Member | null) => {
   const [value, setValue] = useState("");
 
   /** 💡 Use rewind to get the last message from the channel. See https://ably.com/docs/channels/options/rewind 💡 */
-  const channelName = `[?rewind=1]${getSpaceNameFromUrl()}-${componentName}`;
-  const { channel } = useChannel(channelName, (message: Types.Message) => {
-    if (message.connectionId === self?.connectionId) return;
-    setValue(message.data);
-  });
+  const channelName = `${getSpaceNameFromUrl()}-${componentName}`;
+  const { channel } = useChannel(
+    { channelName, options: { params: { rewind: "1" } } },
+    (message: Types.Message) => {
+      if (message.connectionId === self?.connectionId) return;
+      setValue(message.data);
+    },
+  );
 
   const handleChange = useCallback(
     (nextValue: string) => {


### PR DESCRIPTION
The query string syntax no longer works in the latest versions of react-hooks